### PR TITLE
adds host_name arg to SMBFS constructor and opener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,12 @@ ENV/
 
 # Codacy token
 .codacy.token
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode

--- a/fs/opener/smbfs.py
+++ b/fs/opener/smbfs.py
@@ -56,7 +56,7 @@ class SMBOpener(Opener):
             port=smb_port,
             timeout=params.getint('smbfs', 'timeout', fallback=15),
             name_port=params.getint('smbfs', 'name-port', fallback=137),
-            direct_tcp=params.getboolean('smbfs', 'direct-tcp', fallback=False),
+            direct_tcp=params.getboolean('smbfs', 'direct-tcp', fallback=False)
         )
 
         try:

--- a/fs/opener/smbfs.py
+++ b/fs/opener/smbfs.py
@@ -47,15 +47,16 @@ class SMBOpener(Opener):
         params = configparser.ConfigParser()
         params.read_dict({'smbfs':getattr(parse_result, 'params', {})})
 
+        smb_hostname = params.get('smbfs', 'hostname', fallback=None)
+
         smb_fs = SMBFS(
-            smb_host,
+            (smb_host, smb_hostname),
             username=parse_result.username or 'guest',
             passwd=parse_result.password or '',
             port=smb_port,
             timeout=params.getint('smbfs', 'timeout', fallback=15),
             name_port=params.getint('smbfs', 'name-port', fallback=137),
             direct_tcp=params.getboolean('smbfs', 'direct-tcp', fallback=False),
-            host_name=params.get('smbfs', 'host-name', fallback=None)
         )
 
         try:

--- a/fs/opener/smbfs.py
+++ b/fs/opener/smbfs.py
@@ -54,7 +54,8 @@ class SMBOpener(Opener):
             port=smb_port,
             timeout=params.getint('smbfs', 'timeout', fallback=15),
             name_port=params.getint('smbfs', 'name-port', fallback=137),
-            direct_tcp=params.getboolean('smbfs', 'direct-tcp', fallback=False)
+            direct_tcp=params.getboolean('smbfs', 'direct-tcp', fallback=False),
+            host_name=params.get('smbfs', 'host-name', fallback=None)
         )
 
         try:

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -202,17 +202,21 @@ class SMBFS(FS):
         return Info(info)
 
     def __init__(self, host, username='guest', passwd='', timeout=15,
-                 port=139, name_port=137, direct_tcp=False):  # noqa: D102
+                 port=139, name_port=137, direct_tcp=False, host_name=None):  # noqa: D102
         super(SMBFS, self).__init__()
 
-        try:
-            self._server_name, self._server_ip = utils.get_hostname_and_ip(
-                host, self.NETBIOS,
-                timeout=timeout,
-                name_port=name_port
-            )
-        except Exception:
-            raise errors.CreateFailed("could not get IP/host pair from '{}'".format(host))
+        if host_name is not None:
+            self._server_name = host_name
+            self._server_ip = host
+        else:
+            try:
+                self._server_name, self._server_ip = utils.get_hostname_and_ip(
+                    host, self.NETBIOS,
+                    timeout=timeout,
+                    name_port=name_port
+                )
+            except Exception:
+                raise errors.CreateFailed("could not get IP/host pair from '{}'".format(host))
 
         self._timeout = timeout
         self._server_port = port

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -202,21 +202,17 @@ class SMBFS(FS):
         return Info(info)
 
     def __init__(self, host, username='guest', passwd='', timeout=15,
-                 port=139, name_port=137, direct_tcp=False, host_name=None):  # noqa: D102
+                 port=139, name_port=137, direct_tcp=False):  # noqa: D102
         super(SMBFS, self).__init__()
 
-        if host_name is not None:
-            self._server_name = host_name
-            self._server_ip = host
-        else:
-            try:
-                self._server_name, self._server_ip = utils.get_hostname_and_ip(
-                    host, self.NETBIOS,
-                    timeout=timeout,
-                    name_port=name_port
-                )
-            except Exception:
-                raise errors.CreateFailed("could not get IP/host pair from '{}'".format(host))
+        try:
+            self._server_name, self._server_ip = utils.get_hostname_and_ip(
+                host, self.NETBIOS,
+                timeout=timeout,
+                name_port=name_port
+            )
+        except Exception:
+            raise errors.CreateFailed("could not get IP/host pair from '{}'".format(host))
 
         self._timeout = timeout
         self._server_port = port

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -7,9 +7,11 @@ import unittest
 import six
 import fs.errors
 import fs.path
+from fs.smbfs import SMBFS
 from semantic_version import Version
 
 from . import utils
+from .utils import mock
 
 
 @unittest.skipUnless(utils.DOCKER, "docker service unreachable.")
@@ -41,6 +43,12 @@ class TestSMBOpener(unittest.TestCase):
 
     def test_ip(self):
         self.fs = fs.open_fs('smb://rio:letsdance@127.0.0.1/')
+
+    @mock.patch.object(SMBFS, 'NETBIOS', mock.MagicMock())
+    def test_hostname_and_ip(self):
+        self.fs = fs.open_fs('smb://rio:letsdance@127.0.0.1/?hostname=SAMBAALPINE')
+        SMBFS.NETBIOS.queryIPforName.assert_not_called()
+        SMBFS.NETBIOS.queryName.assert_not_called()
 
     def test_create(self):
 


### PR DESCRIPTION
fixes #2

Adds a `host_name` arg to the SMBFS constructor/opener. Useful for when you can't lookup the host name via netbios, such as when no netbios server is running, or when you're trying to connect to a share on your local machine. When `host_name` is explicitly specified, the `host` arg is assumed to contain the the host ip.