### PR TITLE
delegate choice of default smb port to pysmb

### DIFF
--- a/fs/opener/smbfs.py
+++ b/fs/opener/smbfs.py
@@ -41,7 +41,7 @@ class SMBOpener(Opener):
         from ..smbfs import SMBFS
         smb_host, _, dir_path = parse_result.resource.partition('/')
         smb_host, _, smb_port = smb_host.partition(':')
-        smb_port = int(smb_port) if smb_port.isdigit() else 445
+        smb_port = int(smb_port) if smb_port.isdigit() else None
 
 
         params = configparser.ConfigParser()

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -202,7 +202,7 @@ class SMBFS(FS):
         return Info(info)
 
     def __init__(self, host, username='guest', passwd='', timeout=15,
-                 port=139, name_port=137, direct_tcp=False):  # noqa: D102
+                 port=None, name_port=137, direct_tcp=False):  # noqa: D102
         super(SMBFS, self).__init__()
 
         try:
@@ -226,8 +226,12 @@ class SMBFS(FS):
             is_direct_tcp=direct_tcp,
         )
 
+        connect_kw = dict(timeout=self._timeout)
+        if self._server_port is not None:
+            connect_kw['port'] = self._server_port
+
         try:
-            self._smb.connect(self._server_ip, port, timeout=timeout)
+            self._smb.connect(self._server_ip, **connect_kw)
         except (IOError, OSError):
             raise errors.CreateFailed("could not connect to '{}'".format(host))
 

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -50,6 +50,11 @@ class TestSMBOpener(unittest.TestCase):
         SMBFS.NETBIOS.queryIPforName.assert_not_called()
         SMBFS.NETBIOS.queryName.assert_not_called()
 
+    def test_default_smb_port(self):
+        self.fs = fs.open_fs('smb://rio:letsdance@127.0.0.1/')
+
+        self.assertEqual(self.fs._smb.sock.getpeername()[1], 139)
+
     def test_create(self):
 
         directory = "data/test/directory"

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -55,6 +55,11 @@ class TestSMBOpener(unittest.TestCase):
 
         self.assertEqual(self.fs._smb.sock.getpeername()[1], 139)
 
+    def test_explicit_smb_port(self):
+        self.fs = fs.open_fs('smb://rio:letsdance@127.0.0.1:445/?direct-tcp=True')
+
+        self.assertEqual(self.fs._smb.sock.getpeername()[1], 445)
+
     def test_create(self):
 
         directory = "data/test/directory"

--- a/tests/test_smbfs.py
+++ b/tests/test_smbfs.py
@@ -230,3 +230,8 @@ class TestSMBFSConnection(unittest.TestCase):
             fs.errors.CreateFailed,
             self.open_smbfs, None
         )
+
+    def test_default_smb_port(self):
+        smbfs = self.open_smbfs("127.0.0.1")
+
+        self.assertEqual(smbfs._smb.sock.getpeername()[1], 139)

--- a/tests/test_smbfs.py
+++ b/tests/test_smbfs.py
@@ -183,8 +183,8 @@ class TestSMBFSConnection(unittest.TestCase):
     user = "rio"
     pasw = "letsdance"
 
-    def open_smbfs(self, host_token):
-        return SMBFS(host_token, self.user, self.pasw)
+    def open_smbfs(self, host_token, port=None, direct_tcp=False):
+        return SMBFS(host_token, self.user, self.pasw, port=port, direct_tcp=direct_tcp)
 
     @utils.py2expectedFailure
     def test_hostname(self):
@@ -235,3 +235,8 @@ class TestSMBFSConnection(unittest.TestCase):
         smbfs = self.open_smbfs("127.0.0.1")
 
         self.assertEqual(smbfs._smb.sock.getpeername()[1], 139)
+
+    def test_explicit_smb_port(self):
+        smbfs = self.open_smbfs("127.0.0.1", port=445, direct_tcp=True)
+
+        self.assertEqual(smbfs._smb.sock.getpeername()[1], 445)


### PR DESCRIPTION
fixes #8

This PR removes all hardcoded values for the default smb port from this package, and leaves the choice of default smb port up to smb.SMBConnection.SMBConnection.connect from pysmb. Effectively this means that the default smb port in fs.smbfs will now be 139 everywhere, instead of 139 in some places and 445 in others.

~Now I just need to come up with a decent test~

I've now added tests for the default smb port. I also added tests for setting an explicit smb port, because codacy complained:

https://travis-ci.org/github/althonos/fs.smbfs/jobs/674929272