### PR TITLE
upgraded pysmb spec to `~=1.2`; moved reqs to setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,27 +33,6 @@ packages = fs.smbfs, fs.opener
 test_suite = tests
 setup_requires =
   setuptools
-install_requires =
-  configparser ~= 3.2 ; python_version < '3'
-  fs ~=2.2
-  pysmb ~=1.1.22, !=1.1.26
-  six ~=1.10
-tests_require =
-  docker ~=3.6
-  mock ~=2.0 ; python_version < '3.4'
-  semantic_version ~=2.6
-
-[options.extras_require]
-dev =
-  docutils
-  Pygments
-  codecov
-  green
-  coverage
-test =
-  docker ~=3.6
-  mock ~=2.0 ; python_version < '3.4'
-  semantic_version ~=2.6
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,30 @@
 
 import setuptools
 
+install_requires = [
+    'configparser~=3.2; python_version<"3"',
+    'fs~=2.2',
+    'pysmb~=1.2',
+    'six~=1.10',
+]
+
+dev_requires = [
+    'codecov',
+    'coverage',
+    'green',
+    'docutils',
+    'Pygments',
+]
+
+test_requires = [
+    'docker~=3.6',
+    'mock~=2.0; python_version<"3.4"',
+    'semantic_version~=2.6'
+]
+
 setuptools.setup(
-    setup_requires=['green', 'docutils', 'Pygments'],
+    install_requires=install_requires,
+    extras_require={
+        'dev': dev_requires + test_requires
+    },
 )


### PR DESCRIPTION
fixes #14

- upgrades pysmb version specification to `~=1.2`

- pip was ignoring requirements and version specifications when they were in setup.cfg. This PR moves everything but `setup_requires` to setup.py.