### PR TITLE
Convert sharenames to lowercase before lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following people contributed to `fs.sshfs`:
 - [Isaac Jackson](https://github.com/Vegemash)
 - [Max Klein](https://github.com/telamonian)
 - [Francesco Frassinelli](https://github.com/frafra)
+- [Josiah Witheford](https://github.com/josiahwitheford)
 
 This project obviously owes a lot to the PyFilesystem2 project and
 [all its contributors](https://github.com/PyFilesystem/pyfilesystem2/blob/master/CONTRIBUTORS.md).

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -236,7 +236,7 @@ class SMBFS(FS):
             raise errors.CreateFailed("could not connect to '{}'".format(host))
 
         self._shares = {
-            share.name.casefold()
+            share.name.lower()
             for share in self._smb.listShares()
             if share.type == share.DISK_TREE
         }
@@ -482,7 +482,7 @@ class SMBFS(FS):
         # different casing.
         # Note: This currently only handles the python3.3+ implementations. Need
         # to find a way to handle it for older python versions.
-        elif share.casefold() not in self._shares:
+        elif share.lower() not in self._shares:
             raise errors.ResourceNotFound(path)
 
         try:

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -236,7 +236,7 @@ class SMBFS(FS):
             raise errors.CreateFailed("could not connect to '{}'".format(host))
 
         self._shares = {
-            share.name
+            share.name.casefold()
             for share in self._smb.listShares()
             if share.type == share.DISK_TREE
         }
@@ -477,7 +477,12 @@ class SMBFS(FS):
 
         if not share:
             return self._make_root_info(namespaces)
-        elif share not in self._shares:
+        # Shares are case insensitive, however the lookup in python is not.
+        # This causes issues when looking for shares that exist, albeit with 
+        # different casing.
+        # Note: This currently only handles the python3.3+ implementations. Need
+        # to find a way to handle it for older python versions.
+        elif share.casefold() not in self._shares:
             raise errors.ResourceNotFound(path)
 
         try:

--- a/fs/smbfs/smbfs.py
+++ b/fs/smbfs/smbfs.py
@@ -25,6 +25,11 @@ from ..permissions import Permissions
 from . import utils
 from .file import SMBFile
 
+if six.PY2:
+    casefold = unicode.lower
+else:
+    casefold = str.casefold
+
 
 __all__ = ['SMBFS']
 
@@ -236,7 +241,7 @@ class SMBFS(FS):
             raise errors.CreateFailed("could not connect to '{}'".format(host))
 
         self._shares = {
-            share.name.lower()
+            casefold(share.name)
             for share in self._smb.listShares()
             if share.type == share.DISK_TREE
         }
@@ -482,7 +487,7 @@ class SMBFS(FS):
         # different casing.
         # Note: This currently only handles the python3.3+ implementations. Need
         # to find a way to handle it for older python versions.
-        elif share.lower() not in self._shares:
+        elif casefold(share) not in self._shares:
             raise errors.ResourceNotFound(path)
 
         try:


### PR DESCRIPTION
Given a share:
  - share_one
Checking smbfs.exists('SHARE_one') failed because the internal _shares dictionary doesn't contain the capitilized, "SHARE_one", it only had "share_one".

Samba doesn't care about casing so these 2 shares should be the same.

This fixes that issue for python3.3+ clients, however I am not too sure
about how to approach it for python2. (I don't really have any
experience working on python2 systems so this compatibility is foreign
to me.)